### PR TITLE
reduced number of no suchfieldexceptions for pojo style models

### DIFF
--- a/src/main/java/org/apache/sling/scripting/sightly/render/ObjectModel.java
+++ b/src/main/java/org/apache/sling/scripting/sightly/render/ObjectModel.java
@@ -118,10 +118,10 @@ public final class ObjectModel {
                     resolved = ((Map) target).get(property);
                 }
                 if (resolved == null) {
-                    resolved = getField(target, propertyName);
+                    resolved = invokeBeanMethod(target, propertyName);
                 }
                 if (resolved == null) {
-                    resolved = invokeBeanMethod(target, propertyName);
+                    resolved = getField(target, propertyName);
                 }
             }
         }


### PR DESCRIPTION
Hi,

we see very high numbers of exceptions under heavy load on author and publish instances because of the way getField is implemented. As every of our models is written in java bean style with getters and setters, we decided to inverse the retrieval order for properties from field first to method first. This has dramatically reduced the amount of exceptions generated (around 200.000 per minute in our case) and improved the render performance up to 10%.

As invokeBeanMethod does not generate an exception if the method is not found the performance impact for models which rely on public field access should not be that big. 