### PR TITLE
SLING-9314 - NPE in ObjectModel.toBoolean(Object) when object.toString() returns null

### DIFF
--- a/src/main/java/org/apache/sling/scripting/sightly/render/ObjectModel.java
+++ b/src/main/java/org/apache/sling/scripting/sightly/render/ObjectModel.java
@@ -158,7 +158,10 @@ public final class ObjectModel {
             return !(number.doubleValue() == 0.0);
         }
 
-        String s = object.toString().trim();
+        String s = object.toString();
+        if (s != null) {
+            s = s.trim();
+        }
         if (EMPTY_STRING.equals(s)) {
             return false;
         } else if ("true".equalsIgnoreCase(s) || "false".equalsIgnoreCase(s)) {

--- a/src/main/java/org/apache/sling/scripting/sightly/render/ObjectModel.java
+++ b/src/main/java/org/apache/sling/scripting/sightly/render/ObjectModel.java
@@ -155,25 +155,28 @@ public final class ObjectModel {
 
         if (object instanceof Number) {
             Number number = (Number) object;
-            return !(number.doubleValue() == 0.0);
+            return number.doubleValue() != 0.0;
         }
 
-        String s = object.toString();
-        if (s != null) {
-            s = s.trim();
-        }
-        if (EMPTY_STRING.equals(s)) {
-            return false;
-        } else if ("true".equalsIgnoreCase(s) || "false".equalsIgnoreCase(s)) {
-            return Boolean.parseBoolean(s);
+        if (object instanceof Boolean) {
+            return Boolean.TRUE.equals(object);
         }
 
-        if (object instanceof Collection) {
-            return ((Collection) object).size() > 0;
+        if (object instanceof String) {
+            String s = (String) object;
+            if (EMPTY_STRING.equals(s)) {
+                return false;
+            } else if ("true".equalsIgnoreCase(s) || "false".equalsIgnoreCase(s)) {
+                return Boolean.parseBoolean(s);
+            }
         }
 
-        if (object instanceof Map) {
-            return ((Map) object).size() > 0;
+        if (object instanceof Collection<?>) {
+            return !((Collection<?>) object).isEmpty();
+        }
+
+        if (object instanceof Map<?, ?>) {
+            return !((Map<?, ?>) object).isEmpty();
         }
 
         if (object instanceof Iterable<?>) {
@@ -184,11 +187,15 @@ public final class ObjectModel {
             return ((Iterator<?>) object).hasNext();
         }
 
-        if (object instanceof Optional) {
-            return toBoolean(((Optional) object).orElse(false));
+        if (object instanceof Optional<?>) {
+            Optional<?> optional = (Optional<?>) object;
+            return optional.filter(ObjectModel::toBoolean).isPresent();
         }
 
-        return !(object instanceof Object[]) || ((Object[]) object).length > 0;
+        if (object.getClass().isArray()) {
+            return Array.getLength(object) > 0;
+        }
+        return true;
     }
 
     /**

--- a/src/test/java/org/apache/sling/scripting/sightly/render/ObjectModelTest.java
+++ b/src/test/java/org/apache/sling/scripting/sightly/render/ObjectModelTest.java
@@ -48,6 +48,9 @@ public class ObjectModelTest {
         assertFalse(ObjectModel.toBoolean(0));
         assertTrue(ObjectModel.toBoolean(123456));
         assertFalse(ObjectModel.toBoolean(""));
+        assertFalse(ObjectModel.toBoolean(false));
+        assertFalse(ObjectModel.toBoolean(Boolean.FALSE));
+        assertFalse(ObjectModel.toBoolean(new int[0]));
         assertFalse(ObjectModel.toBoolean("FalSe"));
         assertFalse(ObjectModel.toBoolean("false"));
         assertFalse(ObjectModel.toBoolean("FALSE"));

--- a/src/test/java/org/apache/sling/scripting/sightly/render/ObjectModelTest.java
+++ b/src/test/java/org/apache/sling/scripting/sightly/render/ObjectModelTest.java
@@ -81,6 +81,17 @@ public class ObjectModelTest {
         assertTrue(ObjectModel.toBoolean(Optional.of(true)));
         assertTrue(ObjectModel.toBoolean(Optional.of("pass")));
         assertTrue(ObjectModel.toBoolean(Optional.of(1)));
+        assertTrue(ObjectModel.toBoolean(new Object()));
+        Map<String, String> map2 = new HashMap<String, String>() {
+            @Override
+            public String toString() {
+                return null;
+            }
+        };
+        assertFalse(ObjectModel.toBoolean(map2));
+        map2.put("one", "entry");
+        assertTrue(ObjectModel.toBoolean(map2));
+
     }
 
     @Test


### PR DESCRIPTION
* avoid NPEs from classes which do not correctly override Object#toString()