### PR TITLE
SLING-13054 - Improve code coverage and migrate to JUnit 5 for Scripting HTL Runtime

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,16 @@
             <version>2.2</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <!-- ======================================================================= -->

--- a/pom.xml
+++ b/pom.xml
@@ -49,9 +49,10 @@
     </scm>
 
     <properties>
-        <jacoco.maven.plugin.version>0.8.2</jacoco.maven.plugin.version>
+        <jacoco.maven.plugin.version>0.8.11</jacoco.maven.plugin.version>
         <sling.java.version>8</sling.java.version>
         <project.build.outputTimestamp>2021-04-23T16:34:16Z</project.build.outputTimestamp>
+        <sonar.coverage.jacoco.xmlReportPaths>${project.build.directory}/site/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
     </properties>
 
     <!-- ======================================================================= -->
@@ -115,7 +116,7 @@
         <profile>
             <id>coverage-report</id>
             <activation>
-                <activeByDefault>false</activeByDefault>
+                <activeByDefault>true</activeByDefault>
             </activation>
             <build>
                 <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -89,24 +89,8 @@
 
         <!-- testing -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest</artifactId>
-            <version>2.2</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-params</artifactId>
+            <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/test/java/org/apache/sling/scripting/sightly/render/AbstractRuntimeObjectModelTest.java
+++ b/src/test/java/org/apache/sling/scripting/sightly/render/AbstractRuntimeObjectModelTest.java
@@ -46,7 +46,7 @@ public class AbstractRuntimeObjectModelTest {
         assertNull(runtimeObjectModel.resolveProperty(null, null));
         assertNull(runtimeObjectModel.resolveProperty(this, null));
         assertNull(runtimeObjectModel.resolveProperty(this, ""));
-        assertEquals(0, runtimeObjectModel.resolveProperty(Collections.EMPTY_LIST, "size"));
+        assertEquals(0, runtimeObjectModel.resolveProperty(Collections.emptyList(), "size"));
         assertNull(runtimeObjectModel.resolveProperty(null, null));
         int[] ints = new int[] {1, 2, 3};
         assertEquals(ints.length, runtimeObjectModel.resolveProperty(ints, "length"));
@@ -59,30 +59,21 @@ public class AbstractRuntimeObjectModelTest {
         assertEquals(2, runtimeObjectModel.resolveProperty(testList, 1));
         assertNull(runtimeObjectModel.resolveProperty(testList, 3));
         assertNull(runtimeObjectModel.resolveProperty(testList, -1));
-        Map<String, Integer> map = new HashMap<String, Integer>() {
-            {
-                put("one", 1);
-                put("two", 2);
-            }
-        };
+        Map<String, Integer> map = new HashMap<>();
+        map.put("one", 1);
+        map.put("two", 2);
         assertEquals(1, runtimeObjectModel.resolveProperty(map, "one"));
         assertNull(runtimeObjectModel.resolveProperty(map, null));
         assertNull(runtimeObjectModel.resolveProperty(map, ""));
-        Map<Integer, String> stringMap = new HashMap<Integer, String>() {
-            {
-                put(1, "one");
-                put(2, "two");
-            }
-        };
+        Map<Integer, String> stringMap = new HashMap<>();
+        stringMap.put(1, "one");
+        stringMap.put(2, "two");
         assertEquals("one", runtimeObjectModel.resolveProperty(stringMap, 1));
         assertEquals("two", runtimeObjectModel.resolveProperty(stringMap, 2));
-        Map<String, String> strings = new HashMap<String, String>() {
-            {
-                put("a", "one");
-                put("b", "two");
-            }
-        };
-        Record<String> record = new Record<String>() {
+        Map<String, String> strings = new HashMap<>();
+        strings.put("a", "one");
+        strings.put("b", "two");
+        Record<String> records = new Record<String>() {
             @Override
             public String getProperty(String name) {
                 return strings.get(name);
@@ -93,7 +84,7 @@ public class AbstractRuntimeObjectModelTest {
                 return strings.keySet();
             }
         };
-        assertEquals("one", runtimeObjectModel.resolveProperty(record, "a"));
+        assertEquals("one", runtimeObjectModel.resolveProperty(records, "a"));
     }
 
     @Test
@@ -146,14 +137,10 @@ public class AbstractRuntimeObjectModelTest {
     @Test
     public void testToCollection() {
         assertTrue(runtimeObjectModel.toCollection(null).isEmpty());
-        Record<String> record = new Record<String>() {
-
-            private Map<String, String> properties = new HashMap<String, String>() {
-                {
-                    put("a", "1");
-                    put("b", "2");
-                }
-            };
+        final Map<String, String> properties = new HashMap<>();
+        properties.put("a", "1");
+        properties.put("b", "2");
+        Record<String> record1 = new Record<String>() {
 
             @Override
             public String getProperty(String name) {
@@ -165,7 +152,7 @@ public class AbstractRuntimeObjectModelTest {
                 return properties.keySet();
             }
         };
-        Collection testCollection = runtimeObjectModel.toCollection(record);
+        Collection<Object> testCollection = runtimeObjectModel.toCollection(record1);
         assertEquals(2, testCollection.size());
         assertTrue(testCollection.contains("a"));
         assertTrue(testCollection.contains("b"));
@@ -173,14 +160,11 @@ public class AbstractRuntimeObjectModelTest {
 
     @Test
     public void testToMap() {
-        final Map<String, String> properties = new HashMap<String, String>() {
-            {
-                put("a", "1");
-                put("b", "2");
-            }
-        };
+        final Map<String, String> properties = new HashMap<>();
+        properties.put("a", "1");
+        properties.put("b", "2");
         assertEquals(properties, runtimeObjectModel.toMap(properties));
-        Record<String> record = new Record<String>() {
+        Record<String> records = new Record<String>() {
             @Override
             public String getProperty(String name) {
                 return properties.get(name);
@@ -191,7 +175,7 @@ public class AbstractRuntimeObjectModelTest {
                 return properties.keySet();
             }
         };
-        assertEquals(properties, runtimeObjectModel.toMap(record));
+        assertEquals(properties, runtimeObjectModel.toMap(records));
         assertTrue(runtimeObjectModel.toMap(null).isEmpty());
     }
 }

--- a/src/test/java/org/apache/sling/scripting/sightly/render/AbstractRuntimeObjectModelTest.java
+++ b/src/test/java/org/apache/sling/scripting/sightly/render/AbstractRuntimeObjectModelTest.java
@@ -37,12 +37,12 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class AbstractRuntimeObjectModelTest {
+class AbstractRuntimeObjectModelTest {
 
     private AbstractRuntimeObjectModel runtimeObjectModel = new AbstractRuntimeObjectModel() {};
 
     @Test
-    public void testResolveProperty() {
+    void testResolveProperty() {
         assertNull(runtimeObjectModel.resolveProperty(null, null));
         assertNull(runtimeObjectModel.resolveProperty(this, null));
         assertNull(runtimeObjectModel.resolveProperty(this, ""));
@@ -88,7 +88,7 @@ public class AbstractRuntimeObjectModelTest {
     }
 
     @Test
-    public void testToDate() {
+    void testToDate() {
         assertNull(runtimeObjectModel.toDate(null));
         Date testDate = new Date();
         assertEquals(testDate, runtimeObjectModel.toDate(testDate));
@@ -99,7 +99,7 @@ public class AbstractRuntimeObjectModelTest {
     }
 
     @Test
-    public void testToInstant() {
+    void testToInstant() {
         assertNull(runtimeObjectModel.toInstant(null));
         Date testDate = new Date();
         assertEquals(testDate, Date.from(runtimeObjectModel.toInstant(testDate)));
@@ -110,14 +110,14 @@ public class AbstractRuntimeObjectModelTest {
     }
 
     @Test
-    public void testGetPropertyNullChecks() {
+    void testGetPropertyNullChecks() {
         assertNull(runtimeObjectModel.getProperty(null, null));
         assertNull(runtimeObjectModel.getProperty(this, null));
         assertNull(runtimeObjectModel.getProperty(this, ""));
     }
 
     @Test
-    public void testIsDate() {
+    void testIsDate() {
         assertFalse(runtimeObjectModel.isDate(null));
         assertTrue(runtimeObjectModel.isDate(new Date()));
         assertTrue(runtimeObjectModel.isDate(Calendar.getInstance()));
@@ -125,7 +125,7 @@ public class AbstractRuntimeObjectModelTest {
     }
 
     @Test
-    public void testIsNumber() {
+    void testIsNumber() {
         assertFalse(runtimeObjectModel.isNumber(null));
         assertFalse(runtimeObjectModel.isNumber(""));
         assertTrue(runtimeObjectModel.isNumber(0));
@@ -135,7 +135,7 @@ public class AbstractRuntimeObjectModelTest {
     }
 
     @Test
-    public void testToCollection() {
+    void testToCollection() {
         assertTrue(runtimeObjectModel.toCollection(null).isEmpty());
         final Map<String, String> properties = new HashMap<>();
         properties.put("a", "1");
@@ -159,7 +159,7 @@ public class AbstractRuntimeObjectModelTest {
     }
 
     @Test
-    public void testToMap() {
+    void testToMap() {
         final Map<String, String> properties = new HashMap<>();
         properties.put("a", "1");
         properties.put("b", "2");

--- a/src/test/java/org/apache/sling/scripting/sightly/render/AbstractRuntimeObjectModelTest.java
+++ b/src/test/java/org/apache/sling/scripting/sightly/render/AbstractRuntimeObjectModelTest.java
@@ -30,9 +30,12 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.sling.scripting.sightly.Record;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class AbstractRuntimeObjectModelTest {
 

--- a/src/test/java/org/apache/sling/scripting/sightly/render/ObjectModelTest.java
+++ b/src/test/java/org/apache/sling/scripting/sightly/render/ObjectModelTest.java
@@ -20,6 +20,7 @@ package org.apache.sling.scripting.sightly.render;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -28,8 +29,8 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Optional;
-import java.util.Vector;
 
 import org.apache.sling.scripting.sightly.render.testobjects.Person;
 import org.apache.sling.scripting.sightly.render.testobjects.TestEnum;
@@ -48,6 +49,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ObjectModelTest {
 
+    private static final String COMMA_DELIMITED_LIST = "1,2,3";
+    private static final String TEST_URI = "http://localhost/test";
+    private static final String STRING = "string";
+    private static final String INT = "int";
+    private static final String INTEGER = "integer";
+
     @Test
     public void testToBoolean() {
         assertFalse(ObjectModel.toBoolean(null));
@@ -65,22 +72,19 @@ public class ObjectModelTest {
         assertTrue(ObjectModel.toBoolean("TrUE"));
         Integer[] testArray = new Integer[] {1, 2, 3};
         int[] testPrimitiveArray = new int[] {1, 2, 3};
-        List testList = Arrays.asList(testArray);
+        List<?> testList = Arrays.asList(testArray);
         assertTrue(ObjectModel.toBoolean(testArray));
         assertTrue(ObjectModel.toBoolean(testPrimitiveArray));
         assertFalse(ObjectModel.toBoolean(new Integer[] {}));
         assertTrue(ObjectModel.toBoolean(testList));
         assertFalse(ObjectModel.toBoolean(Collections.emptyList()));
-        Map<String, Integer> map = new HashMap<String, Integer>() {
-            {
-                put("one", 1);
-                put("two", 2);
-            }
-        };
+        Map<String, Integer> map = new HashMap<>();
+        map.put("one", 1);
+        map.put("two", 2);
         assertTrue(ObjectModel.toBoolean(map));
-        assertFalse(ObjectModel.toBoolean(Collections.EMPTY_MAP));
+        assertFalse(ObjectModel.toBoolean(Collections.emptyMap()));
         assertTrue(ObjectModel.toBoolean(testList.iterator()));
-        assertFalse(ObjectModel.toBoolean(Collections.EMPTY_LIST.iterator()));
+        assertFalse(ObjectModel.toBoolean(Collections.emptyList().iterator()));
         assertTrue(ObjectModel.toBoolean(new Bag<>(testArray)));
         assertFalse(ObjectModel.toBoolean(new Bag<>(new Integer[] {})));
         assertTrue(ObjectModel.toBoolean(new Date()));
@@ -93,12 +97,7 @@ public class ObjectModelTest {
         assertTrue(ObjectModel.toBoolean(Optional.of("pass")));
         assertTrue(ObjectModel.toBoolean(Optional.of(1)));
         assertTrue(ObjectModel.toBoolean(new Object()));
-        Map<String, String> map2 = new HashMap<String, String>() {
-            @Override
-            public String toString() {
-                return null;
-            }
-        };
+        Map<String, String> map2 = new HashMap<>();
         assertFalse(ObjectModel.toBoolean(map2));
         map2.put("one", "entry");
         assertTrue(ObjectModel.toBoolean(map2));
@@ -128,11 +127,11 @@ public class ObjectModelTest {
         assertEquals("CONSTANT", ObjectModel.toString(TestEnum.CONSTANT));
         Integer[] testArray = new Integer[] {1, 2, 3};
         int[] testPrimitiveArray = new int[] {1, 2, 3};
-        List testList = Arrays.asList(testArray);
-        assertEquals("1,2,3", ObjectModel.toString(testList));
-        assertEquals("1,2,3", ObjectModel.toString(testArray));
-        assertEquals("1,2,3", ObjectModel.toString(testPrimitiveArray));
-        assertEquals("http://localhost/test", ObjectModel.toString(new URI("http://localhost/test")));
+        List<Integer> testList = Arrays.asList(testArray);
+        assertEquals(COMMA_DELIMITED_LIST, ObjectModel.toString(testList));
+        assertEquals(COMMA_DELIMITED_LIST, ObjectModel.toString(testArray));
+        assertEquals(COMMA_DELIMITED_LIST, ObjectModel.toString(testPrimitiveArray));
+        assertEquals(TEST_URI, ObjectModel.toString(new URI(TEST_URI)));
 
         assertEquals("", ObjectModel.toString(Optional.empty()));
         assertEquals("false", ObjectModel.toString(Optional.of(false)));
@@ -151,26 +150,23 @@ public class ObjectModelTest {
         Integer[] testArray = new Integer[] {1, 2, 3};
         int[] testPrimitiveArray = new int[] {1, 2, 3};
         List<Integer> testList = Arrays.asList(testArray);
-        Map<String, Integer> map = new HashMap<String, Integer>() {
-            {
-                put("one", 1);
-                put("two", 2);
-            }
-        };
+        Map<String, Integer> map = new HashMap<>();
+        map.put("one", 1);
+        map.put("two", 2);
         assertEquals(testList, ObjectModel.toCollection(testArray));
         assertEquals(testList, ObjectModel.toCollection(testPrimitiveArray));
         assertEquals(testList, ObjectModel.toCollection(testList));
         MatcherAssert.assertThat(
                 ObjectModel.toCollection(map), Matchers.contains(map.keySet().toArray()));
-        Vector<Integer> vector = new Vector<>(testList);
-        assertEquals(testList, ObjectModel.toCollection(vector.elements()));
+        ArrayList<Integer> arrayList = new ArrayList<>(testList);
+        assertEquals(testList, ObjectModel.toCollection(arrayList));
         assertEquals(testList, ObjectModel.toCollection(testList.iterator()));
         assertEquals(testList, ObjectModel.toCollection(new Bag<>(testArray)));
         String stringObject = "test";
         Integer numberObject = 1;
-        Collection stringCollection = ObjectModel.toCollection(stringObject);
+        Collection<Object> stringCollection = ObjectModel.toCollection(stringObject);
         assertTrue(stringCollection.size() == 1 && stringCollection.contains(stringObject));
-        Collection numberCollection = ObjectModel.toCollection(numberObject);
+        Collection<Object> numberCollection = ObjectModel.toCollection(numberObject);
         assertTrue(numberCollection.size() == 1 && numberCollection.contains(numberObject));
 
         List<Object> emptyList = Collections.emptyList();
@@ -184,16 +180,16 @@ public class ObjectModelTest {
     public void testCollectionToString() {
         assertEquals("", ObjectModel.collectionToString(null));
         Integer[] testArray = new Integer[] {1, 2, 3};
-        List testList = Arrays.asList(testArray);
-        assertEquals("1,2,3", ObjectModel.collectionToString(testList));
+        List<Integer> testList = Arrays.asList(testArray);
+        assertEquals(COMMA_DELIMITED_LIST, ObjectModel.collectionToString(testList));
     }
 
     @Test
     public void testFromIterator() {
         assertTrue(ObjectModel.fromIterator(null).isEmpty());
         Integer[] testArray = new Integer[] {1, 2, 3};
-        List testList = Arrays.asList(testArray);
-        assertEquals(testList, ObjectModel.fromIterator(testList.iterator()));
+        List<Integer> testList = Arrays.asList(testArray);
+        assertEquals(testList, ObjectModel.fromIterator((Iterator) testList.iterator()));
     }
 
     @Test
@@ -201,7 +197,7 @@ public class ObjectModelTest {
         assertNull(ObjectModel.resolveProperty(null, 0));
         assertNull(ObjectModel.resolveProperty(this, null));
         assertNull(ObjectModel.resolveProperty(null, null));
-        assertEquals(0, ObjectModel.resolveProperty(Collections.EMPTY_LIST, "size"));
+        assertEquals(0, ObjectModel.resolveProperty(Collections.emptyList(), "size"));
         Integer[] testArray = new Integer[] {1, 2, 3};
         assertEquals(2, ObjectModel.resolveProperty(testArray, 1));
         assertNull(ObjectModel.resolveProperty(testArray, 3));
@@ -210,21 +206,15 @@ public class ObjectModelTest {
         assertEquals(2, ObjectModel.resolveProperty(testList, 1));
         assertNull(ObjectModel.resolveProperty(testList, 3));
         assertNull(ObjectModel.resolveProperty(testList, -1));
-        Map<String, Integer> map = new HashMap<String, Integer>() {
-            {
-                put("one", 1);
-                put("two", 2);
-            }
-        };
+        Map<String, Integer> map = new HashMap<>();
+        map.put("one", 1);
+        map.put("two", 2);
         assertEquals(1, ObjectModel.resolveProperty(map, "one"));
         assertNull(ObjectModel.resolveProperty(map, null));
         assertNull(ObjectModel.resolveProperty(map, ""));
-        Map<Integer, String> stringMap = new HashMap<Integer, String>() {
-            {
-                put(1, "one");
-                put(2, "two");
-            }
-        };
+        Map<Integer, String> stringMap = new HashMap<>();
+        stringMap.put(1, "one");
+        stringMap.put(2, "two");
         assertEquals("one", ObjectModel.resolveProperty(stringMap, 1));
         assertEquals("two", ObjectModel.resolveProperty(stringMap, 2));
         Person johnDoe = AdultFactory.createAdult("John", "Doe");
@@ -248,13 +238,12 @@ public class ObjectModelTest {
         assertNull(ObjectModel.resolveProperty(johnDoe, "nomethod"), "Expected null result for inexistent method.");
 
         OptionalTest optionalTest = new OptionalTest();
-        assertEquals(Optional.of("string"), ObjectModel.resolveProperty(optionalTest, "string"));
-        assertEquals(Optional.of(1), ObjectModel.resolveProperty(optionalTest, "int"));
-        assertEquals(Optional.of(1), ObjectModel.resolveProperty(Optional.of(optionalTest), "int"));
-        assertEquals(Optional.of(Integer.valueOf(1)), ObjectModel.resolveProperty(optionalTest, "integer"));
-        assertEquals(
-                Optional.of(Integer.valueOf(1)), ObjectModel.resolveProperty(Optional.of(optionalTest), "integer"));
-        assertEquals(null, ObjectModel.resolveProperty(Optional.empty(), "integer"));
+        assertEquals(Optional.of(STRING), ObjectModel.resolveProperty(optionalTest, STRING));
+        assertEquals(Optional.of(1), ObjectModel.resolveProperty(optionalTest, INT));
+        assertEquals(Optional.of(1), ObjectModel.resolveProperty(Optional.of(optionalTest), INT));
+        assertEquals(Optional.of(Integer.valueOf(1)), ObjectModel.resolveProperty(optionalTest, INTEGER));
+        assertEquals(Optional.of(Integer.valueOf(1)), ObjectModel.resolveProperty(Optional.of(optionalTest), INTEGER));
+        assertEquals(null, ObjectModel.resolveProperty(Optional.empty(), INTEGER));
     }
 
     /**
@@ -298,12 +287,9 @@ public class ObjectModelTest {
         assertEquals(2, ObjectModel.getIndex(testList, 1));
         assertNull(ObjectModel.getIndex(testList, 3));
         assertNull(ObjectModel.getIndex(testList, -1));
-        Map<Integer, String> stringMap = new HashMap<Integer, String>() {
-            {
-                put(1, "one");
-                put(2, "two");
-            }
-        };
+        Map<Integer, String> stringMap = new HashMap<>();
+        stringMap.put(1, "one");
+        stringMap.put(2, "two");
         assertNull(ObjectModel.getIndex(stringMap, 1));
         assertNull(ObjectModel.getIndex(stringMap, 2));
     }
@@ -355,11 +341,16 @@ public class ObjectModelTest {
 
                 @Override
                 public T next() {
+                    if (!hasNext()) {
+                        throw new NoSuchElementException();
+                    }
                     return backingArray[index++];
                 }
 
                 @Override
-                public void remove() {}
+                public void remove() {
+                    throw new UnsupportedOperationException();
+                }
             };
         }
     }
@@ -370,7 +361,7 @@ public class ObjectModelTest {
         }
 
         public Optional<String> getString() {
-            return Optional.of("string");
+            return Optional.of(STRING);
         }
 
         public Optional<Integer> getInt() {

--- a/src/test/java/org/apache/sling/scripting/sightly/render/ObjectModelTest.java
+++ b/src/test/java/org/apache/sling/scripting/sightly/render/ObjectModelTest.java
@@ -53,6 +53,11 @@ class ObjectModelTest {
     private static final String INT = "int";
     private static final String INTEGER = "integer";
 
+    private static final Integer[] TEST_ARRAY = new Integer[] {1, 2, 3};
+    private static final int[] TEST_PRIMITIVE_ARRAY = new int[] {1, 2, 3};
+
+    private static final List<Integer> TEST_LIST = Arrays.asList(TEST_ARRAY);
+
     @Test
     void testToBoolean() {
         assertFalse(ObjectModel.toBoolean(null));
@@ -68,22 +73,19 @@ class ObjectModelTest {
         assertTrue(ObjectModel.toBoolean("true"));
         assertTrue(ObjectModel.toBoolean("TRUE"));
         assertTrue(ObjectModel.toBoolean("TrUE"));
-        Integer[] testArray = new Integer[] {1, 2, 3};
-        int[] testPrimitiveArray = new int[] {1, 2, 3};
-        List<?> testList = Arrays.asList(testArray);
-        assertTrue(ObjectModel.toBoolean(testArray));
-        assertTrue(ObjectModel.toBoolean(testPrimitiveArray));
+        assertTrue(ObjectModel.toBoolean(TEST_ARRAY));
+        assertTrue(ObjectModel.toBoolean(TEST_PRIMITIVE_ARRAY));
         assertFalse(ObjectModel.toBoolean(new Integer[] {}));
-        assertTrue(ObjectModel.toBoolean(testList));
+        assertTrue(ObjectModel.toBoolean(TEST_LIST));
         assertFalse(ObjectModel.toBoolean(Collections.emptyList()));
         Map<String, Integer> map = new HashMap<>();
         map.put("one", 1);
         map.put("two", 2);
         assertTrue(ObjectModel.toBoolean(map));
         assertFalse(ObjectModel.toBoolean(Collections.emptyMap()));
-        assertTrue(ObjectModel.toBoolean(testList.iterator()));
+        assertTrue(ObjectModel.toBoolean(TEST_LIST.iterator()));
         assertFalse(ObjectModel.toBoolean(Collections.emptyList().iterator()));
-        assertTrue(ObjectModel.toBoolean(new Bag<>(testArray)));
+        assertTrue(ObjectModel.toBoolean(new Bag<>(TEST_ARRAY)));
         assertFalse(ObjectModel.toBoolean(new Bag<>(new Integer[] {})));
         assertTrue(ObjectModel.toBoolean(new Date()));
 
@@ -123,12 +125,9 @@ class ObjectModelTest {
         assertEquals("1", ObjectModel.toString("1"));
         assertEquals("1", ObjectModel.toString(1));
         assertEquals("CONSTANT", ObjectModel.toString(TestEnum.CONSTANT));
-        Integer[] testArray = new Integer[] {1, 2, 3};
-        int[] testPrimitiveArray = new int[] {1, 2, 3};
-        List<Integer> testList = Arrays.asList(testArray);
-        assertEquals(COMMA_DELIMITED_LIST, ObjectModel.toString(testList));
-        assertEquals(COMMA_DELIMITED_LIST, ObjectModel.toString(testArray));
-        assertEquals(COMMA_DELIMITED_LIST, ObjectModel.toString(testPrimitiveArray));
+        assertEquals(COMMA_DELIMITED_LIST, ObjectModel.toString(TEST_LIST));
+        assertEquals(COMMA_DELIMITED_LIST, ObjectModel.toString(TEST_ARRAY));
+        assertEquals(COMMA_DELIMITED_LIST, ObjectModel.toString(TEST_PRIMITIVE_ARRAY));
         assertEquals(TEST_URI, ObjectModel.toString(new URI(TEST_URI)));
 
         assertEquals("", ObjectModel.toString(Optional.empty()));
@@ -145,21 +144,18 @@ class ObjectModelTest {
         assertTrue(ObjectModel.toCollection(null).isEmpty());
         StringBuilder sb = new StringBuilder();
         assertEquals(Collections.singletonList(sb), ObjectModel.toCollection(sb));
-        Integer[] testArray = new Integer[] {1, 2, 3};
-        int[] testPrimitiveArray = new int[] {1, 2, 3};
-        List<Integer> testList = Arrays.asList(testArray);
         Map<String, Integer> map = new HashMap<>();
         map.put("one", 1);
         map.put("two", 2);
-        assertEquals(testList, ObjectModel.toCollection(testArray));
-        assertEquals(testList, ObjectModel.toCollection(testPrimitiveArray));
-        assertEquals(testList, ObjectModel.toCollection(testList));
+        assertEquals(TEST_LIST, ObjectModel.toCollection(TEST_ARRAY));
+        assertEquals(TEST_LIST, ObjectModel.toCollection(TEST_PRIMITIVE_ARRAY));
+        assertEquals(TEST_LIST, ObjectModel.toCollection(TEST_LIST));
         Collection<Object> mapCollection = ObjectModel.toCollection(map);
         assertTrue(mapCollection.containsAll(map.keySet()) && mapCollection.size() == map.size());
-        ArrayList<Integer> arrayList = new ArrayList<>(testList);
-        assertEquals(testList, ObjectModel.toCollection(arrayList));
-        assertEquals(testList, ObjectModel.toCollection(testList.iterator()));
-        assertEquals(testList, ObjectModel.toCollection(new Bag<>(testArray)));
+        ArrayList<Integer> arrayList = new ArrayList<>(TEST_LIST);
+        assertEquals(TEST_LIST, ObjectModel.toCollection(arrayList));
+        assertEquals(TEST_LIST, ObjectModel.toCollection(TEST_LIST.iterator()));
+        assertEquals(TEST_LIST, ObjectModel.toCollection(new Bag<>(TEST_ARRAY)));
         String stringObject = "test";
         Integer numberObject = 1;
         Collection<Object> stringCollection = ObjectModel.toCollection(stringObject);
@@ -177,17 +173,13 @@ class ObjectModelTest {
     @Test
     void testCollectionToString() {
         assertEquals("", ObjectModel.collectionToString(null));
-        Integer[] testArray = new Integer[] {1, 2, 3};
-        List<Integer> testList = Arrays.asList(testArray);
-        assertEquals(COMMA_DELIMITED_LIST, ObjectModel.collectionToString(testList));
+        assertEquals(COMMA_DELIMITED_LIST, ObjectModel.collectionToString(TEST_LIST));
     }
 
     @Test
     void testFromIterator() {
         assertTrue(ObjectModel.fromIterator(null).isEmpty());
-        Integer[] testArray = new Integer[] {1, 2, 3};
-        List<Integer> testList = Arrays.asList(testArray);
-        assertEquals(testList, ObjectModel.fromIterator((Iterator) testList.iterator()));
+        assertEquals(TEST_LIST, ObjectModel.fromIterator((Iterator) TEST_LIST.iterator()));
     }
 
     @Test
@@ -196,14 +188,12 @@ class ObjectModelTest {
         assertNull(ObjectModel.resolveProperty(this, null));
         assertNull(ObjectModel.resolveProperty(null, null));
         assertEquals(0, ObjectModel.resolveProperty(Collections.emptyList(), "size"));
-        Integer[] testArray = new Integer[] {1, 2, 3};
-        assertEquals(2, ObjectModel.resolveProperty(testArray, 1));
-        assertNull(ObjectModel.resolveProperty(testArray, 3));
-        assertNull(ObjectModel.resolveProperty(testArray, -1));
-        List<Integer> testList = Arrays.asList(testArray);
-        assertEquals(2, ObjectModel.resolveProperty(testList, 1));
-        assertNull(ObjectModel.resolveProperty(testList, 3));
-        assertNull(ObjectModel.resolveProperty(testList, -1));
+        assertEquals(2, ObjectModel.resolveProperty(TEST_ARRAY, 1));
+        assertNull(ObjectModel.resolveProperty(TEST_ARRAY, 3));
+        assertNull(ObjectModel.resolveProperty(TEST_ARRAY, -1));
+        assertEquals(2, ObjectModel.resolveProperty(TEST_LIST, 1));
+        assertNull(ObjectModel.resolveProperty(TEST_LIST, 3));
+        assertNull(ObjectModel.resolveProperty(TEST_LIST, -1));
         Map<String, Integer> map = new HashMap<>();
         map.put("one", 1);
         map.put("two", 2);
@@ -225,7 +215,7 @@ class ObjectModelTest {
                 "Did not expect to be able to access public fields from package protected classes.");
         assertEquals(
                 3,
-                ObjectModel.resolveProperty(testArray, "length"),
+                ObjectModel.resolveProperty(TEST_ARRAY, "length"),
                 "Expected to be able to access an array's length property.");
         assertNotNull(
                 ObjectModel.resolveProperty(johnDoe, "lastName"),
@@ -277,14 +267,12 @@ class ObjectModelTest {
     @Test
     void testGetIndex() {
         assertNull(ObjectModel.getIndex(null, 0));
-        Integer[] testArray = new Integer[] {1, 2, 3};
-        assertEquals(2, ObjectModel.getIndex(testArray, 1));
-        assertNull(ObjectModel.getIndex(testArray, 3));
-        assertNull(ObjectModel.getIndex(testArray, -1));
-        List<Integer> testList = Arrays.asList(testArray);
-        assertEquals(2, ObjectModel.getIndex(testList, 1));
-        assertNull(ObjectModel.getIndex(testList, 3));
-        assertNull(ObjectModel.getIndex(testList, -1));
+        assertEquals(2, ObjectModel.getIndex(TEST_ARRAY, 1));
+        assertNull(ObjectModel.getIndex(TEST_ARRAY, 3));
+        assertNull(ObjectModel.getIndex(TEST_ARRAY, -1));
+        assertEquals(2, ObjectModel.getIndex(TEST_LIST, 1));
+        assertNull(ObjectModel.getIndex(TEST_LIST, 3));
+        assertNull(ObjectModel.getIndex(TEST_LIST, -1));
         Map<Integer, String> stringMap = new HashMap<>();
         stringMap.put(1, "one");
         stringMap.put(2, "two");

--- a/src/test/java/org/apache/sling/scripting/sightly/render/ObjectModelTest.java
+++ b/src/test/java/org/apache/sling/scripting/sightly/render/ObjectModelTest.java
@@ -38,7 +38,6 @@ import org.apache.sling.scripting.sightly.render.testobjects.TestEnum2;
 import org.apache.sling.scripting.sightly.render.testobjects.internal.AdultFactory;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -195,7 +194,6 @@ class ObjectModelTest {
     void testResolveProperty() {
         Person johnDoe = AdultFactory.createAdult("John", "Doe");
         OptionalTest optionalTest = new OptionalTest();
-
         Map<String, Integer> map = new HashMap<>();
         map.put("one", 1);
         map.put("two", 2);
@@ -204,67 +202,64 @@ class ObjectModelTest {
         stringMap.put(1, "one");
         stringMap.put(2, "two");
 
-        assertAll(
-                "Null and Boundary Checks",
-                () -> assertNull(ObjectModel.resolveProperty(null, 0)),
-                () -> assertNull(ObjectModel.resolveProperty(this, null)),
-                () -> assertNull(ObjectModel.resolveProperty(null, null)),
-                () -> assertNull(ObjectModel.resolveProperty(TEST_ARRAY, 3)),
-                () -> assertNull(ObjectModel.resolveProperty(TEST_ARRAY, -1)),
-                () -> assertNull(ObjectModel.resolveProperty(TEST_LIST, 3)),
-                () -> assertNull(ObjectModel.resolveProperty(TEST_LIST, -1)));
+        PropertyTestCase[] cases = {
+            new PropertyTestCase(null, 0, null, null),
+            new PropertyTestCase(this, null, null, null),
+            new PropertyTestCase(null, null, null, null),
+            new PropertyTestCase(Collections.emptyList(), "size", 0, null),
+            new PropertyTestCase(TEST_ARRAY, 1, 2, null),
+            new PropertyTestCase(TEST_ARRAY, 3, null, null),
+            new PropertyTestCase(TEST_ARRAY, -1, null, null),
+            new PropertyTestCase(TEST_LIST, 1, 2, null),
+            new PropertyTestCase(TEST_LIST, 3, null, null),
+            new PropertyTestCase(TEST_LIST, -1, null, null),
+            new PropertyTestCase(map, "one", 1, null),
+            new PropertyTestCase(map, null, null, null),
+            new PropertyTestCase(map, "", null, null),
+            new PropertyTestCase(stringMap, 1, "one", null),
+            new PropertyTestCase(stringMap, 2, "two", null),
+            new PropertyTestCase(
+                    johnDoe, "CONSTANT", 1L, "Expected to be able to access public static final constants."),
+            new PropertyTestCase(
+                    johnDoe,
+                    "TODAY",
+                    null,
+                    "Did not expect to be able to access public fields from package protected classes."),
+            new PropertyTestCase(TEST_ARRAY, "length", 3, "Expected to be able to access an array's length property."),
+            new PropertyTestCase(
+                    johnDoe,
+                    "fullName",
+                    null,
+                    "Expected null result for public method available on implementation but not exposed by interface."),
+            new PropertyTestCase(johnDoe, "nomethod", null, "Expected null result for inexistent method."),
+            new PropertyTestCase(optionalTest, STRING, Optional.of(STRING), null),
+            new PropertyTestCase(optionalTest, INT, Optional.of(1), null),
+            new PropertyTestCase(Optional.of(optionalTest), INT, Optional.of(1), null),
+            new PropertyTestCase(optionalTest, INTEGER, Optional.of(1), null),
+            new PropertyTestCase(Optional.of(optionalTest), INTEGER, Optional.of(1), null),
+            new PropertyTestCase(Optional.empty(), INTEGER, null, null)
+        };
 
-        assertAll(
-                "Indexed Access",
-                () -> assertEquals(2, ObjectModel.resolveProperty(TEST_ARRAY, 1)),
-                () -> assertEquals(2, ObjectModel.resolveProperty(TEST_LIST, 1)),
-                () -> assertEquals(
-                        3,
-                        ObjectModel.resolveProperty(TEST_ARRAY, "length"),
-                        "Expected to be able to access an array's length property."));
+        for (PropertyTestCase c : cases) {
+            assertEquals(c.expected, ObjectModel.resolveProperty(c.target, c.property), c.message);
+        }
+        assertNotNull(
+                ObjectModel.resolveProperty(johnDoe, "lastName"),
+                "Expected not null result for invocation of interface method on implementation class.");
+    }
 
-        assertAll(
-                "Map Access",
-                () -> assertEquals(1, ObjectModel.resolveProperty(map, "one")),
-                () -> assertNull(ObjectModel.resolveProperty(map, null)),
-                () -> assertNull(ObjectModel.resolveProperty(map, "")),
-                () -> assertEquals("one", ObjectModel.resolveProperty(stringMap, 1)),
-                () -> assertEquals("two", ObjectModel.resolveProperty(stringMap, 2)));
+    private static class PropertyTestCase {
+        Object target;
+        Object property;
+        Object expected;
+        String message;
 
-        assertAll(
-                "POJO Properties",
-                () -> assertEquals(
-                        1L,
-                        ObjectModel.resolveProperty(johnDoe, "CONSTANT"),
-                        "Expected to be able to access public static final constants."),
-                () -> assertNull(
-                        ObjectModel.resolveProperty(johnDoe, "TODAY"),
-                        "Did not expect to be able to access public fields from package protected classes."),
-                () -> assertNotNull(
-                        ObjectModel.resolveProperty(johnDoe, "lastName"),
-                        "Expected not null result for invocation of interface method on implementation class."));
-
-        assertAll(
-                "Negative POJO checks",
-                () -> assertNull(
-                        ObjectModel.resolveProperty(johnDoe, "fullName"),
-                        "Expected null result for public method available on implementation but not exposed by interface."),
-                () -> assertNull(
-                        ObjectModel.resolveProperty(johnDoe, "nomethod"),
-                        "Expected null result for inexistent method."));
-
-        assertEquals(0, ObjectModel.resolveProperty(Collections.emptyList(), "size"));
-
-        assertAll(
-                "Optional Support",
-                () -> assertEquals(Optional.of(STRING), ObjectModel.resolveProperty(optionalTest, STRING)),
-                () -> assertEquals(Optional.of(1), ObjectModel.resolveProperty(optionalTest, INT)),
-                () -> assertEquals(Optional.of(1), ObjectModel.resolveProperty(Optional.of(optionalTest), INT)),
-                () -> assertEquals(Optional.of(Integer.valueOf(1)), ObjectModel.resolveProperty(optionalTest, INTEGER)),
-                () -> assertEquals(
-                        Optional.of(Integer.valueOf(1)),
-                        ObjectModel.resolveProperty(Optional.of(optionalTest), INTEGER)),
-                () -> assertNull(ObjectModel.resolveProperty(Optional.empty(), INTEGER)));
+        PropertyTestCase(Object target, Object property, Object expected, String message) {
+            this.target = target;
+            this.property = property;
+            this.expected = expected;
+            this.message = message;
+        }
     }
 
     /**

--- a/src/test/java/org/apache/sling/scripting/sightly/render/ObjectModelTest.java
+++ b/src/test/java/org/apache/sling/scripting/sightly/render/ObjectModelTest.java
@@ -193,6 +193,9 @@ class ObjectModelTest {
 
     @Test
     void testResolveProperty() {
+        Person johnDoe = AdultFactory.createAdult("John", "Doe");
+        OptionalTest optionalTest = new OptionalTest();
+
         Map<String, Integer> map = new HashMap<>();
         map.put("one", 1);
         map.put("two", 2);
@@ -201,26 +204,35 @@ class ObjectModelTest {
         stringMap.put(1, "one");
         stringMap.put(2, "two");
 
-        Person johnDoe = AdultFactory.createAdult("John", "Doe");
-        OptionalTest optionalTest = new OptionalTest();
-
         assertAll(
-                "Property Resolution",
+                "Null and Boundary Checks",
                 () -> assertNull(ObjectModel.resolveProperty(null, 0)),
                 () -> assertNull(ObjectModel.resolveProperty(this, null)),
                 () -> assertNull(ObjectModel.resolveProperty(null, null)),
-                () -> assertEquals(0, ObjectModel.resolveProperty(Collections.emptyList(), "size")),
-                () -> assertEquals(2, ObjectModel.resolveProperty(TEST_ARRAY, 1)),
                 () -> assertNull(ObjectModel.resolveProperty(TEST_ARRAY, 3)),
                 () -> assertNull(ObjectModel.resolveProperty(TEST_ARRAY, -1)),
-                () -> assertEquals(2, ObjectModel.resolveProperty(TEST_LIST, 1)),
                 () -> assertNull(ObjectModel.resolveProperty(TEST_LIST, 3)),
-                () -> assertNull(ObjectModel.resolveProperty(TEST_LIST, -1)),
+                () -> assertNull(ObjectModel.resolveProperty(TEST_LIST, -1)));
+
+        assertAll(
+                "Indexed Access",
+                () -> assertEquals(2, ObjectModel.resolveProperty(TEST_ARRAY, 1)),
+                () -> assertEquals(2, ObjectModel.resolveProperty(TEST_LIST, 1)),
+                () -> assertEquals(
+                        3,
+                        ObjectModel.resolveProperty(TEST_ARRAY, "length"),
+                        "Expected to be able to access an array's length property."));
+
+        assertAll(
+                "Map Access",
                 () -> assertEquals(1, ObjectModel.resolveProperty(map, "one")),
                 () -> assertNull(ObjectModel.resolveProperty(map, null)),
                 () -> assertNull(ObjectModel.resolveProperty(map, "")),
                 () -> assertEquals("one", ObjectModel.resolveProperty(stringMap, 1)),
-                () -> assertEquals("two", ObjectModel.resolveProperty(stringMap, 2)),
+                () -> assertEquals("two", ObjectModel.resolveProperty(stringMap, 2)));
+
+        assertAll(
+                "POJO Properties",
                 () -> assertEquals(
                         1L,
                         ObjectModel.resolveProperty(johnDoe, "CONSTANT"),
@@ -228,19 +240,23 @@ class ObjectModelTest {
                 () -> assertNull(
                         ObjectModel.resolveProperty(johnDoe, "TODAY"),
                         "Did not expect to be able to access public fields from package protected classes."),
-                () -> assertEquals(
-                        3,
-                        ObjectModel.resolveProperty(TEST_ARRAY, "length"),
-                        "Expected to be able to access an array's length property."),
                 () -> assertNotNull(
                         ObjectModel.resolveProperty(johnDoe, "lastName"),
-                        "Expected not null result for invocation of interface method on implementation class."),
+                        "Expected not null result for invocation of interface method on implementation class."));
+
+        assertAll(
+                "Negative POJO checks",
                 () -> assertNull(
                         ObjectModel.resolveProperty(johnDoe, "fullName"),
                         "Expected null result for public method available on implementation but not exposed by interface."),
                 () -> assertNull(
                         ObjectModel.resolveProperty(johnDoe, "nomethod"),
-                        "Expected null result for inexistent method."),
+                        "Expected null result for inexistent method."));
+
+        assertEquals(0, ObjectModel.resolveProperty(Collections.emptyList(), "size"));
+
+        assertAll(
+                "Optional Support",
                 () -> assertEquals(Optional.of(STRING), ObjectModel.resolveProperty(optionalTest, STRING)),
                 () -> assertEquals(Optional.of(1), ObjectModel.resolveProperty(optionalTest, INT)),
                 () -> assertEquals(Optional.of(1), ObjectModel.resolveProperty(Optional.of(optionalTest), INT)),

--- a/src/test/java/org/apache/sling/scripting/sightly/render/ObjectModelTest.java
+++ b/src/test/java/org/apache/sling/scripting/sightly/render/ObjectModelTest.java
@@ -37,14 +37,14 @@ import org.apache.sling.scripting.sightly.render.testobjects.TestEnum2;
 import org.apache.sling.scripting.sightly.render.testobjects.internal.AdultFactory;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ObjectModelTest {
 

--- a/src/test/java/org/apache/sling/scripting/sightly/render/ObjectModelTest.java
+++ b/src/test/java/org/apache/sling/scripting/sightly/render/ObjectModelTest.java
@@ -45,7 +45,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class ObjectModelTest {
+class ObjectModelTest {
 
     private static final String COMMA_DELIMITED_LIST = "1,2,3";
     private static final String TEST_URI = "http://localhost/test";
@@ -54,7 +54,7 @@ public class ObjectModelTest {
     private static final String INTEGER = "integer";
 
     @Test
-    public void testToBoolean() {
+    void testToBoolean() {
         assertFalse(ObjectModel.toBoolean(null));
         assertFalse(ObjectModel.toBoolean(0));
         assertTrue(ObjectModel.toBoolean(123456));
@@ -102,7 +102,7 @@ public class ObjectModelTest {
     }
 
     @Test
-    public void testToNumber() {
+    void testToNumber() {
         assertEquals(1, ObjectModel.toNumber(1));
         assertEquals(1, ObjectModel.toNumber("1"));
         assertNull(ObjectModel.toNumber(null));
@@ -118,7 +118,7 @@ public class ObjectModelTest {
     }
 
     @Test
-    public void testToString() throws URISyntaxException {
+    void testToString() throws URISyntaxException {
         assertEquals("", ObjectModel.toString(null));
         assertEquals("1", ObjectModel.toString("1"));
         assertEquals("1", ObjectModel.toString(1));
@@ -141,7 +141,7 @@ public class ObjectModelTest {
     }
 
     @Test
-    public void testToCollection() {
+    void testToCollection() {
         assertTrue(ObjectModel.toCollection(null).isEmpty());
         StringBuilder sb = new StringBuilder();
         assertEquals(Collections.singletonList(sb), ObjectModel.toCollection(sb));
@@ -175,7 +175,7 @@ public class ObjectModelTest {
     }
 
     @Test
-    public void testCollectionToString() {
+    void testCollectionToString() {
         assertEquals("", ObjectModel.collectionToString(null));
         Integer[] testArray = new Integer[] {1, 2, 3};
         List<Integer> testList = Arrays.asList(testArray);
@@ -183,7 +183,7 @@ public class ObjectModelTest {
     }
 
     @Test
-    public void testFromIterator() {
+    void testFromIterator() {
         assertTrue(ObjectModel.fromIterator(null).isEmpty());
         Integer[] testArray = new Integer[] {1, 2, 3};
         List<Integer> testList = Arrays.asList(testArray);
@@ -191,7 +191,7 @@ public class ObjectModelTest {
     }
 
     @Test
-    public void testResolveProperty() {
+    void testResolveProperty() {
         assertNull(ObjectModel.resolveProperty(null, 0));
         assertNull(ObjectModel.resolveProperty(this, null));
         assertNull(ObjectModel.resolveProperty(null, null));
@@ -249,7 +249,7 @@ public class ObjectModelTest {
      * by their name
      */
     @Test
-    public void testResolvePropertyFromEnum() {
+    void testResolvePropertyFromEnum() {
         assertEquals(TestEnum2.ONE, ObjectModel.resolveProperty(TestEnum2.class, "ONE"));
         assertEquals(TestEnum2.TWO, ObjectModel.resolveProperty(TestEnum2.class, "TWO"));
         assertNull(ObjectModel.resolveProperty(TestEnum.class, "INVALID"));
@@ -264,7 +264,7 @@ public class ObjectModelTest {
      * Verify that values of an static method of an enumeration can be invoked
      */
     @Test
-    public void testResolveMethodFromEnum() {
+    void testResolveMethodFromEnum() {
         Object value = ObjectModel.resolveProperty(TestEnum2.class, "values");
         assertNotNull(value);
         assertTrue(value.getClass().isArray());
@@ -275,7 +275,7 @@ public class ObjectModelTest {
     }
 
     @Test
-    public void testGetIndex() {
+    void testGetIndex() {
         assertNull(ObjectModel.getIndex(null, 0));
         Integer[] testArray = new Integer[] {1, 2, 3};
         assertEquals(2, ObjectModel.getIndex(testArray, 1));
@@ -297,7 +297,7 @@ public class ObjectModelTest {
      * by their ordinal value
      */
     @Test
-    public void testGetIndexFromEnum() {
+    void testGetIndexFromEnum() {
         assertEquals(TestEnum2.ONE, ObjectModel.getIndex(TestEnum2.class, 0));
         Object two = ObjectModel.getIndex(TestEnum2.class, 1);
         assertEquals(TestEnum2.TWO, two);
@@ -306,7 +306,7 @@ public class ObjectModelTest {
     }
 
     @Test
-    public void testClassBasedMethodsForNulls() {
+    void testClassBasedMethodsForNulls() {
         assertNull(ObjectModel.getField(null, null));
         assertNull(ObjectModel.getField("", null));
         assertNull(ObjectModel.getField(this, ""));

--- a/src/test/java/org/apache/sling/scripting/sightly/render/ObjectModelTest.java
+++ b/src/test/java/org/apache/sling/scripting/sightly/render/ObjectModelTest.java
@@ -36,8 +36,6 @@ import org.apache.sling.scripting.sightly.render.testobjects.Person;
 import org.apache.sling.scripting.sightly.render.testobjects.TestEnum;
 import org.apache.sling.scripting.sightly.render.testobjects.TestEnum2;
 import org.apache.sling.scripting.sightly.render.testobjects.internal.AdultFactory;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -156,8 +154,8 @@ public class ObjectModelTest {
         assertEquals(testList, ObjectModel.toCollection(testArray));
         assertEquals(testList, ObjectModel.toCollection(testPrimitiveArray));
         assertEquals(testList, ObjectModel.toCollection(testList));
-        MatcherAssert.assertThat(
-                ObjectModel.toCollection(map), Matchers.contains(map.keySet().toArray()));
+        Collection<Object> mapCollection = ObjectModel.toCollection(map);
+        assertTrue(mapCollection.containsAll(map.keySet()) && mapCollection.size() == map.size());
         ArrayList<Integer> arrayList = new ArrayList<>(testList);
         assertEquals(testList, ObjectModel.toCollection(arrayList));
         assertEquals(testList, ObjectModel.toCollection(testList.iterator()));

--- a/src/test/java/org/apache/sling/scripting/sightly/render/ObjectModelTest.java
+++ b/src/test/java/org/apache/sling/scripting/sightly/render/ObjectModelTest.java
@@ -38,6 +38,7 @@ import org.apache.sling.scripting.sightly.render.testobjects.TestEnum2;
 import org.apache.sling.scripting.sightly.render.testobjects.internal.AdultFactory;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -56,51 +57,59 @@ class ObjectModelTest {
     private static final Integer[] TEST_ARRAY = new Integer[] {1, 2, 3};
     private static final int[] TEST_PRIMITIVE_ARRAY = new int[] {1, 2, 3};
 
-    private static final List<Integer> TEST_LIST = Arrays.asList(TEST_ARRAY);
+    private static final List<Integer> TEST_LIST = Collections.unmodifiableList(Arrays.asList(TEST_ARRAY));
 
     @Test
     void testToBoolean() {
-        assertFalse(ObjectModel.toBoolean(null));
-        assertFalse(ObjectModel.toBoolean(0));
-        assertTrue(ObjectModel.toBoolean(123456));
-        assertFalse(ObjectModel.toBoolean(""));
-        assertFalse(ObjectModel.toBoolean(false));
-        assertFalse(ObjectModel.toBoolean(Boolean.FALSE));
-        assertFalse(ObjectModel.toBoolean(new int[0]));
-        assertTrue(ObjectModel.toBoolean("FalSe"));
-        assertTrue(ObjectModel.toBoolean("false"));
-        assertTrue(ObjectModel.toBoolean("FALSE"));
-        assertTrue(ObjectModel.toBoolean("true"));
-        assertTrue(ObjectModel.toBoolean("TRUE"));
-        assertTrue(ObjectModel.toBoolean("TrUE"));
-        assertTrue(ObjectModel.toBoolean(TEST_ARRAY));
-        assertTrue(ObjectModel.toBoolean(TEST_PRIMITIVE_ARRAY));
-        assertFalse(ObjectModel.toBoolean(new Integer[] {}));
-        assertTrue(ObjectModel.toBoolean(TEST_LIST));
-        assertFalse(ObjectModel.toBoolean(Collections.emptyList()));
-        Map<String, Integer> map = new HashMap<>();
-        map.put("one", 1);
-        map.put("two", 2);
-        assertTrue(ObjectModel.toBoolean(map));
-        assertFalse(ObjectModel.toBoolean(Collections.emptyMap()));
-        assertTrue(ObjectModel.toBoolean(TEST_LIST.iterator()));
-        assertFalse(ObjectModel.toBoolean(Collections.emptyList().iterator()));
-        assertTrue(ObjectModel.toBoolean(new Bag<>(TEST_ARRAY)));
-        assertFalse(ObjectModel.toBoolean(new Bag<>(new Integer[] {})));
-        assertTrue(ObjectModel.toBoolean(new Date()));
+        Map<String, String> populatedMap = new HashMap<>();
+        populatedMap.put("one", "entry");
 
-        assertFalse(ObjectModel.toBoolean(Optional.empty()));
-        assertFalse(ObjectModel.toBoolean(Optional.of("")));
-        assertFalse(ObjectModel.toBoolean(Optional.of(false)));
-        assertFalse(ObjectModel.toBoolean(Optional.ofNullable(null)));
-        assertTrue(ObjectModel.toBoolean(Optional.of(true)));
-        assertTrue(ObjectModel.toBoolean(Optional.of("pass")));
-        assertTrue(ObjectModel.toBoolean(Optional.of(1)));
-        assertTrue(ObjectModel.toBoolean(new Object()));
-        Map<String, String> map2 = new HashMap<>();
-        assertFalse(ObjectModel.toBoolean(map2));
-        map2.put("one", "entry");
-        assertTrue(ObjectModel.toBoolean(map2));
+        Object[] falsyInputs = {
+            null,
+            0,
+            "",
+            false,
+            Boolean.FALSE,
+            new int[0],
+            new Integer[] {},
+            Collections.emptyList(),
+            Collections.emptyMap(),
+            new HashMap<>(),
+            Collections.emptyList().iterator(),
+            new Bag<>(new Integer[] {}),
+            Optional.empty(),
+            Optional.of(""),
+            Optional.of(false),
+            Optional.ofNullable(null)
+        };
+
+        Object[] truthyInputs = {
+            123456,
+            "FalSe",
+            "false",
+            "FALSE",
+            "true",
+            "TRUE",
+            "TrUE",
+            TEST_ARRAY,
+            TEST_PRIMITIVE_ARRAY,
+            TEST_LIST,
+            TEST_LIST.iterator(),
+            new Bag<>(TEST_ARRAY),
+            new Date(),
+            new Object(),
+            populatedMap,
+            Optional.of(true),
+            Optional.of("pass"),
+            Optional.of(1)
+        };
+
+        for (Object input : falsyInputs) {
+            assertFalse(ObjectModel.toBoolean(input), "Should be false for: " + input);
+        }
+        for (Object input : truthyInputs) {
+            assertTrue(ObjectModel.toBoolean(input), "Should be true for: " + input);
+        }
     }
 
     @Test
@@ -184,54 +193,62 @@ class ObjectModelTest {
 
     @Test
     void testResolveProperty() {
-        assertNull(ObjectModel.resolveProperty(null, 0));
-        assertNull(ObjectModel.resolveProperty(this, null));
-        assertNull(ObjectModel.resolveProperty(null, null));
-        assertEquals(0, ObjectModel.resolveProperty(Collections.emptyList(), "size"));
-        assertEquals(2, ObjectModel.resolveProperty(TEST_ARRAY, 1));
-        assertNull(ObjectModel.resolveProperty(TEST_ARRAY, 3));
-        assertNull(ObjectModel.resolveProperty(TEST_ARRAY, -1));
-        assertEquals(2, ObjectModel.resolveProperty(TEST_LIST, 1));
-        assertNull(ObjectModel.resolveProperty(TEST_LIST, 3));
-        assertNull(ObjectModel.resolveProperty(TEST_LIST, -1));
         Map<String, Integer> map = new HashMap<>();
         map.put("one", 1);
         map.put("two", 2);
-        assertEquals(1, ObjectModel.resolveProperty(map, "one"));
-        assertNull(ObjectModel.resolveProperty(map, null));
-        assertNull(ObjectModel.resolveProperty(map, ""));
+
         Map<Integer, String> stringMap = new HashMap<>();
         stringMap.put(1, "one");
         stringMap.put(2, "two");
-        assertEquals("one", ObjectModel.resolveProperty(stringMap, 1));
-        assertEquals("two", ObjectModel.resolveProperty(stringMap, 2));
-        Person johnDoe = AdultFactory.createAdult("John", "Doe");
-        assertEquals(
-                1l,
-                ObjectModel.resolveProperty(johnDoe, "CONSTANT"),
-                "Expected to be able to access public static final constants.");
-        assertNull(
-                ObjectModel.resolveProperty(johnDoe, "TODAY"),
-                "Did not expect to be able to access public fields from package protected classes.");
-        assertEquals(
-                3,
-                ObjectModel.resolveProperty(TEST_ARRAY, "length"),
-                "Expected to be able to access an array's length property.");
-        assertNotNull(
-                ObjectModel.resolveProperty(johnDoe, "lastName"),
-                "Expected not null result for invocation of interface method on implementation class.");
-        assertNull(
-                ObjectModel.resolveProperty(johnDoe, "fullName"),
-                "Expected null result for public method available on implementation but not exposed by interface.");
-        assertNull(ObjectModel.resolveProperty(johnDoe, "nomethod"), "Expected null result for inexistent method.");
 
+        Person johnDoe = AdultFactory.createAdult("John", "Doe");
         OptionalTest optionalTest = new OptionalTest();
-        assertEquals(Optional.of(STRING), ObjectModel.resolveProperty(optionalTest, STRING));
-        assertEquals(Optional.of(1), ObjectModel.resolveProperty(optionalTest, INT));
-        assertEquals(Optional.of(1), ObjectModel.resolveProperty(Optional.of(optionalTest), INT));
-        assertEquals(Optional.of(Integer.valueOf(1)), ObjectModel.resolveProperty(optionalTest, INTEGER));
-        assertEquals(Optional.of(Integer.valueOf(1)), ObjectModel.resolveProperty(Optional.of(optionalTest), INTEGER));
-        assertEquals(null, ObjectModel.resolveProperty(Optional.empty(), INTEGER));
+
+        assertAll(
+                "Property Resolution",
+                () -> assertNull(ObjectModel.resolveProperty(null, 0)),
+                () -> assertNull(ObjectModel.resolveProperty(this, null)),
+                () -> assertNull(ObjectModel.resolveProperty(null, null)),
+                () -> assertEquals(0, ObjectModel.resolveProperty(Collections.emptyList(), "size")),
+                () -> assertEquals(2, ObjectModel.resolveProperty(TEST_ARRAY, 1)),
+                () -> assertNull(ObjectModel.resolveProperty(TEST_ARRAY, 3)),
+                () -> assertNull(ObjectModel.resolveProperty(TEST_ARRAY, -1)),
+                () -> assertEquals(2, ObjectModel.resolveProperty(TEST_LIST, 1)),
+                () -> assertNull(ObjectModel.resolveProperty(TEST_LIST, 3)),
+                () -> assertNull(ObjectModel.resolveProperty(TEST_LIST, -1)),
+                () -> assertEquals(1, ObjectModel.resolveProperty(map, "one")),
+                () -> assertNull(ObjectModel.resolveProperty(map, null)),
+                () -> assertNull(ObjectModel.resolveProperty(map, "")),
+                () -> assertEquals("one", ObjectModel.resolveProperty(stringMap, 1)),
+                () -> assertEquals("two", ObjectModel.resolveProperty(stringMap, 2)),
+                () -> assertEquals(
+                        1L,
+                        ObjectModel.resolveProperty(johnDoe, "CONSTANT"),
+                        "Expected to be able to access public static final constants."),
+                () -> assertNull(
+                        ObjectModel.resolveProperty(johnDoe, "TODAY"),
+                        "Did not expect to be able to access public fields from package protected classes."),
+                () -> assertEquals(
+                        3,
+                        ObjectModel.resolveProperty(TEST_ARRAY, "length"),
+                        "Expected to be able to access an array's length property."),
+                () -> assertNotNull(
+                        ObjectModel.resolveProperty(johnDoe, "lastName"),
+                        "Expected not null result for invocation of interface method on implementation class."),
+                () -> assertNull(
+                        ObjectModel.resolveProperty(johnDoe, "fullName"),
+                        "Expected null result for public method available on implementation but not exposed by interface."),
+                () -> assertNull(
+                        ObjectModel.resolveProperty(johnDoe, "nomethod"),
+                        "Expected null result for inexistent method."),
+                () -> assertEquals(Optional.of(STRING), ObjectModel.resolveProperty(optionalTest, STRING)),
+                () -> assertEquals(Optional.of(1), ObjectModel.resolveProperty(optionalTest, INT)),
+                () -> assertEquals(Optional.of(1), ObjectModel.resolveProperty(Optional.of(optionalTest), INT)),
+                () -> assertEquals(Optional.of(Integer.valueOf(1)), ObjectModel.resolveProperty(optionalTest, INTEGER)),
+                () -> assertEquals(
+                        Optional.of(Integer.valueOf(1)),
+                        ObjectModel.resolveProperty(Optional.of(optionalTest), INTEGER)),
+                () -> assertNull(ObjectModel.resolveProperty(Optional.empty(), INTEGER)));
     }
 
     /**

--- a/src/test/java/org/apache/sling/scripting/sightly/render/ObjectModelTest.java
+++ b/src/test/java/org/apache/sling/scripting/sightly/render/ObjectModelTest.java
@@ -229,23 +229,23 @@ public class ObjectModelTest {
         assertEquals("two", ObjectModel.resolveProperty(stringMap, 2));
         Person johnDoe = AdultFactory.createAdult("John", "Doe");
         assertEquals(
-                "Expected to be able to access public static final constants.",
                 1l,
-                ObjectModel.resolveProperty(johnDoe, "CONSTANT"));
+                ObjectModel.resolveProperty(johnDoe, "CONSTANT"),
+                "Expected to be able to access public static final constants.");
         assertNull(
-                "Did not expect to be able to access public fields from package protected classes.",
-                ObjectModel.resolveProperty(johnDoe, "TODAY"));
+                ObjectModel.resolveProperty(johnDoe, "TODAY"),
+                "Did not expect to be able to access public fields from package protected classes.");
         assertEquals(
-                "Expected to be able to access an array's length property.",
                 3,
-                ObjectModel.resolveProperty(testArray, "length"));
+                ObjectModel.resolveProperty(testArray, "length"),
+                "Expected to be able to access an array's length property.");
         assertNotNull(
-                "Expected not null result for invocation of interface method on implementation class.",
-                ObjectModel.resolveProperty(johnDoe, "lastName"));
+                ObjectModel.resolveProperty(johnDoe, "lastName"),
+                "Expected not null result for invocation of interface method on implementation class.");
         assertNull(
-                "Expected null result for public method available on implementation but not exposed by interface.",
-                ObjectModel.resolveProperty(johnDoe, "fullName"));
-        assertNull("Expected null result for inexistent method.", ObjectModel.resolveProperty(johnDoe, "nomethod"));
+                ObjectModel.resolveProperty(johnDoe, "fullName"),
+                "Expected null result for public method available on implementation but not exposed by interface.");
+        assertNull(ObjectModel.resolveProperty(johnDoe, "nomethod"), "Expected null result for inexistent method.");
 
         OptionalTest optionalTest = new OptionalTest();
         assertEquals(Optional.of("string"), ObjectModel.resolveProperty(optionalTest, "string"));
@@ -268,9 +268,9 @@ public class ObjectModelTest {
         assertNull(ObjectModel.resolveProperty(TestEnum.class, "INVALID"));
 
         assertEquals(
-                "Expected to be able to access public static final constants.",
                 TestEnum2.STR_CONSTANT,
-                ObjectModel.resolveProperty(TestEnum2.class, "STR_CONSTANT"));
+                ObjectModel.resolveProperty(TestEnum2.class, "STR_CONSTANT"),
+                "Expected to be able to access public static final constants.");
     }
 
     /**


### PR DESCRIPTION
Migrate tests to JUnit 5 and refactor codebase to address SonarQube quality and maintenance issues

- Added JUnit 5 dependencies and replaced legacy imports
- Fixed assertion argument order for JUnit 5 methods
- Refactored `AbstractRuntimeObjectModelTest` to remove problematic double-brace initialization
- Fixed `Bag.Iterator` in `ObjectModelTest` to throw NoSuchElementException per SonarQube java:S2272
- Replaced `Vector` with `ArrayList` and introduced constants for duplicated string literals
- Removed legacy JUnit 4 and Hamcrest dependencies from `pom.xml`
- Refactored all remaining Hamcrest assertions to native JUnit 5 assertions
- enable automated JaCoCo code coverage reporting
- Refactored `ObjectModelTest` to use a data-driven approach for property resolution tests
- Refactored to imporve readability and structure of ObjectModelTest boolean and property resolution tests by grouping assertions

